### PR TITLE
BlockHash adds fork handling

### DIFF
--- a/common/mock/chain.go
+++ b/common/mock/chain.go
@@ -17,12 +17,14 @@
 package mock
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"math/rand"
 	"reflect"
 	"time"
 
+	"github.com/AlayaNetwork/Alaya-Go/common/vm"
 	"github.com/AlayaNetwork/Alaya-Go/crypto"
 	"github.com/AlayaNetwork/Alaya-Go/crypto/sha3"
 	"github.com/AlayaNetwork/Alaya-Go/rlp"
@@ -609,4 +611,24 @@ func (lhs *MockStateDB) DeepCopy(rhs *MockStateDB) {
 			lhs.Logs[oneAddress] = tempLogs
 		}
 	}
+}
+
+type ActiveVersionValue struct {
+	ActiveVersion uint32 `json:"ActiveVersion"`
+	ActiveBlock   uint64 `json:"ActiveBlock"`
+}
+
+func (state *MockStateDB) GetCurrentActiveVersion() uint32 {
+
+	avListBytes := state.GetState(vm.GovContractAddr, []byte("ActVers"))
+	if len(avListBytes) == 0 {
+		panic("Cannot find active version list")
+	}
+	var avList []ActiveVersionValue
+	if err := json.Unmarshal(avListBytes, &avList); err != nil {
+		panic("invalid active version information")
+	}
+
+	return avList[0].ActiveVersion
+
 }

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -74,6 +74,8 @@ type StateDB interface {
 	TxIdx() uint32
 
 	IntermediateRoot(deleteEmptyObjects bool) common.Hash
+
+	GetCurrentActiveVersion() uint32
 }
 
 // MerkleProof

--- a/core/vm/wagon_runtime.go
+++ b/core/vm/wagon_runtime.go
@@ -828,16 +828,24 @@ func BlockHash(proc *exec.Process, num uint64, dst uint32) {
 	ctx := proc.HostCtx().(*VMContext)
 	checkGas(ctx, GasExtStep)
 
-	// Add get block height limit, same as evm opBlockhash
-	var upper, lower uint64
-	upper = ctx.evm.BlockNumber.Uint64()
-	if upper < 257 {
-		lower = 0
-	} else {
-		lower = upper - 256
-	}
+	// get current version
+	currentValue := ctx.evm.StateDB.GetCurrentActiveVersion()
+
+	// get block hash
 	var blockHash common.Hash
-	if num >= lower && num < upper {
+	if currentValue >= params.FORKVERSION_0_16_0 {
+		// Add get block height limit, same as evm opBlockhash
+		var upper, lower uint64
+		upper = ctx.evm.BlockNumber.Uint64()
+		if upper < 257 {
+			lower = 0
+		} else {
+			lower = upper - 256
+		}
+		if num >= lower && num < upper {
+			blockHash = ctx.evm.GetHash(num)
+		}
+	} else {
 		blockHash = ctx.evm.GetHash(num)
 	}
 

--- a/core/vm/wagon_runtime_test.go
+++ b/core/vm/wagon_runtime_test.go
@@ -5,12 +5,16 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/binary"
-	"github.com/AlayaNetwork/Alaya-Go/common/hexutil"
+	"encoding/json"
 	"hash/fnv"
 	"io/ioutil"
 	"math/big"
 	"strings"
 	"testing"
+
+	"github.com/AlayaNetwork/Alaya-Go/common/hexutil"
+	"github.com/AlayaNetwork/Alaya-Go/common/vm"
+	"github.com/AlayaNetwork/Alaya-Go/x/gov"
 
 	"github.com/AlayaNetwork/Alaya-Go/params"
 
@@ -55,9 +59,20 @@ var testCase = []*Case{
 				GetHash: func(u uint64) common.Hash {
 					return common.Hash{1, 2, 3}
 				}},
+				StateDB: &mock.MockStateDB{
+					Balance: make(map[common.Address]*big.Int),
+					State:   make(map[common.Address]map[string][]byte),
+					Journal: mock.NewJournal(),
+				},
 			},
 		},
 		funcName: "platon_block_hash_test",
+		init: func(self *Case, t *testing.T) {
+			curAv := gov.ActiveVersionValue{ActiveVersion: params.FORKVERSION_0_16_0, ActiveBlock: 1}
+			avList := []gov.ActiveVersionValue{curAv}
+			avListBytes, _ := json.Marshal(avList)
+			self.ctx.evm.StateDB.SetState(vm.GovContractAddr, gov.KeyActiveVersions(), avListBytes)
+		},
 		check: func(self *Case, err error) bool {
 			hash := common.Hash{1, 2, 3}
 			return bytes.Equal(hash[:], self.ctx.Output)
@@ -1588,6 +1603,11 @@ func TestGetBlockHash(t *testing.T) {
 				},
 				BlockNumber: big.NewInt(blockNumber),
 			},
+			StateDB: &mock.MockStateDB{
+				Balance: make(map[common.Address]*big.Int),
+				State:   make(map[common.Address]map[string][]byte),
+				Journal: mock.NewJournal(),
+			},
 		}))
 	}
 
@@ -1596,15 +1616,44 @@ func TestGetBlockHash(t *testing.T) {
 		getNumber   uint64
 		expect      common.Hash
 	}
-	cases := []TestCase{
+
+	// Before upgrading
+	casesBeforUpgrade := []TestCase{
+		{1, 123, testBlockHash},
+		{123, 123, testBlockHash},
+		{123, 122, testBlockHash},
+		{1024, 122, testBlockHash},
+		{1024, 1024 - 256, testBlockHash},
+	}
+	for _, c := range casesBeforUpgrade {
+		proc := newProc(c.blockNumber)
+		ctx := proc.HostCtx().(*VMContext)
+		curAv := gov.ActiveVersionValue{ActiveVersion: params.FORKVERSION_0_15_0, ActiveBlock: 1}
+		avList := []gov.ActiveVersionValue{curAv}
+		avListBytes, _ := json.Marshal(avList)
+		ctx.evm.StateDB.SetState(vm.GovContractAddr, gov.KeyActiveVersions(), avListBytes)
+		BlockHash(proc, c.getNumber, 1024)
+		res := common.Hash{}
+		proc.ReadAt(res[:], 1024)
+		assert.Equal(t, c.expect, res)
+		assert.Equal(t, initExternalGas-GasExtStep, proc.HostCtx().(*VMContext).contract.Gas)
+	}
+
+	// After the upgrade
+	casesAfterUpgrade := []TestCase{
 		{1, 123, common.Hash{}},
 		{123, 123, common.Hash{}},
 		{123, 122, testBlockHash},
 		{1024, 122, common.Hash{}},
 		{1024, 1024 - 256, testBlockHash},
 	}
-	for _, c := range cases {
+	for _, c := range casesAfterUpgrade {
 		proc := newProc(c.blockNumber)
+		ctx := proc.HostCtx().(*VMContext)
+		curAv := gov.ActiveVersionValue{ActiveVersion: params.FORKVERSION_0_16_0, ActiveBlock: 1}
+		avList := []gov.ActiveVersionValue{curAv}
+		avListBytes, _ := json.Marshal(avList)
+		ctx.evm.StateDB.SetState(vm.GovContractAddr, gov.KeyActiveVersions(), avListBytes)
 		BlockHash(proc, c.getNumber, 1024)
 		res := common.Hash{}
 		proc.ReadAt(res[:], 1024)


### PR DESCRIPTION
issue： https://github.com/AlayaNetwork/Alaya-Go/issues/18

Obtaining the block hash too early by the old logic will cause the memory to run out. To query the height limit, only the blocks within 256 before the current block height can be queried.

Version greater than or equal to FORKVERSION_0_16_0 The new logic takes effect, the previous version uses the old logic.