### PR TITLE
feat: add rpc method platon_chainId

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -62,6 +62,15 @@ func (ec *Client) Close() {
 }
 
 // Blockchain Access
+// ChainId retrieves the current chain ID for transaction replay protection.
+func (ec *Client) ChainID(ctx context.Context) (*big.Int, error) {
+	var result hexutil.Big
+	err := ec.c.CallContext(ctx, &result, "platon_chainId")
+	if err != nil {
+		return nil, err
+	}
+	return (*big.Int)(&result), err
+}
 
 // BlockByHash returns the given full block.
 //

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -510,6 +510,15 @@ func NewPublicBlockChainAPI(b Backend) *PublicBlockChainAPI {
 //	return nil
 //}
 
+// ChainId is the EIP-155 replay-protection chain id for the current ethereum chain config.
+func (s *PublicBlockChainAPI) ChainId() (*hexutil.Big, error) {
+	// if current block is at or past the EIP-155 replay-protection fork block, return chainID from config
+	if config := s.b.ChainConfig(); config.IsEIP155(s.b.CurrentBlock().Number()) {
+		return (*hexutil.Big)(config.ChainID), nil
+	}
+	return nil, fmt.Errorf("chain not synced beyond EIP-155 replay-protection fork block")
+}
+
 // BlockNumber returns the block number of the chain head.
 func (s *PublicBlockChainAPI) BlockNumber() hexutil.Uint64 {
 	header, _ := s.b.HeaderByNumber(context.Background(), rpc.LatestBlockNumber) // latest header should always be available

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -428,6 +428,11 @@ web3._extend({
 	property: 'platon',
 	methods: [
 		new web3._extend.Method({
+		name: 'chainId',
+			call: 'platon_chainId',
+			params: 0
+		}),
+		new web3._extend.Method({
 			name: 'setActor',
 			call: 'platon_setActor',
 			params: 1,
@@ -547,7 +552,7 @@ web3._extend({
 			params: 2
 		}),
 		//new web3._extend.Method({
-		//	name: 'deriveAccount',	
+		//	name: 'deriveAccount',
 		//	call: 'personal_deriveAccount',
 		//	params: 3
 		//}),


### PR DESCRIPTION
According EIP-695, add rpc method `platon_chainId`.
And you can get Chain ID via:
1. attach to the console, use `platon.chainId()` to read chain id back, or
2. by curl command, like `curl -X POST http://localhost:6789 -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"platon_chainId","params":[],"id":67}'`