### PR TITLE
fetch chain id while binding to a contract.

### DIFF
--- a/accounts/abi/bind/backend.go
+++ b/accounts/abi/bind/backend.go
@@ -82,6 +82,8 @@ type ContractTransactor interface {
 	EstimateGas(ctx context.Context, call alaya.CallMsg) (gas uint64, err error)
 	// SendTransaction injects the transaction into the pending pool for execution.
 	SendTransaction(ctx context.Context, tx *types.Transaction) error
+	// ChainId to detect the chain id
+	ChainID(ctx context.Context) (*big.Int, error)
 }
 
 // ContractFilterer defines the methods needed to access log events using one-off

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -196,6 +196,12 @@ func (b *SimulatedBackend) CallContract(ctx context.Context, call ethereum.CallM
 	return rval.Return(), nil
 }
 
+
+// ChainId to detect the chain id
+func (b *SimulatedBackend) ChainID(ctx context.Context) (*big.Int, error) {
+	return b.config.ChainID, nil
+}
+
 // PendingCallContract executes a contract call on the pending state.
 func (b *SimulatedBackend) PendingCallContract(ctx context.Context, call ethereum.CallMsg) ([]byte, error) {
 	b.mu.Lock()

--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -247,7 +247,13 @@ func (c *BoundContract) transact(opts *TransactOpts, contract *common.Address, i
 	if opts.Signer == nil {
 		return nil, errors.New("no signer to authorize the transaction with")
 	}
-	signedTx, err := opts.Signer(types.NewEIP155Signer(new(big.Int)), opts.From, rawTx)
+
+	chainId, err := c.transactor.ChainID(ensureContext(opts.Context))
+	if err != nil {
+		return nil, errors.New("read chain id from remote failed")
+	}
+
+	signedTx, err := opts.Signer(types.NewEIP155Signer(chainId), opts.From, rawTx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
when you want to bind or deploy contract, you should provide chain id,
now we can fetch it dynamically from remote.