### PR TITLE
 merge eth 1.9.1

### DIFF
--- a/accounts/usbwallet/wallet.go
+++ b/accounts/usbwallet/wallet.go
@@ -25,12 +25,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/karalabe/hid"
+
 	ethereum "github.com/AlayaNetwork/Alaya-Go"
 	"github.com/AlayaNetwork/Alaya-Go/accounts"
 	"github.com/AlayaNetwork/Alaya-Go/common"
 	"github.com/AlayaNetwork/Alaya-Go/core/types"
 	"github.com/AlayaNetwork/Alaya-Go/log"
-	"github.com/karalabe/hid"
 )
 
 // Maximum time between wallet health checks to detect USB unplugs.
@@ -475,7 +476,8 @@ func (w *wallet) Derive(path accounts.DerivationPath, pin bool) (accounts.Accoun
 
 	if _, ok := w.paths[address]; !ok {
 		w.accounts = append(w.accounts, account)
-		w.paths[address] = path
+		w.paths[address] = make(accounts.DerivationPath, len(path))
+		copy(w.paths[address], path)
 	}
 	return account, nil
 }

--- a/common/bitutil/bitutil_test.go
+++ b/common/bitutil/bitutil_test.go
@@ -190,6 +190,8 @@ func benchmarkBaseOR(b *testing.B, size int) {
 	}
 }
 
+var GloBool bool // Exported global will not be dead-code eliminated, at least not yet.
+
 // Benchmarks the potentially optimized bit testing performance.
 func BenchmarkFastTest1KB(b *testing.B) { benchmarkFastTest(b, 1024) }
 func BenchmarkFastTest2KB(b *testing.B) { benchmarkFastTest(b, 2048) }
@@ -197,9 +199,11 @@ func BenchmarkFastTest4KB(b *testing.B) { benchmarkFastTest(b, 4096) }
 
 func benchmarkFastTest(b *testing.B, size int) {
 	p := make([]byte, size)
+	a := false
 	for i := 0; i < b.N; i++ {
-		TestBytes(p)
+		a = a != TestBytes(p)
 	}
+	GloBool = a // Use of benchmark "result" to prevent total dead code elimination.
 }
 
 // Benchmarks the baseline bit testing performance.
@@ -209,7 +213,9 @@ func BenchmarkBaseTest4KB(b *testing.B) { benchmarkBaseTest(b, 4096) }
 
 func benchmarkBaseTest(b *testing.B, size int) {
 	p := make([]byte, size)
+	a := false
 	for i := 0; i < b.N; i++ {
-		safeTestBytes(p)
+		a = a != safeTestBytes(p)
 	}
+	GloBool = a // Use of benchmark "result" to prevent total dead code elimination.
 }

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -175,7 +175,7 @@ func SetupGenesisBlock(db ethdb.Database, snapshotBaseDB snapshotdb.BaseDB, gene
 			return nil, common.ZeroHash, err
 		}
 		log.Debug("SetupGenesisBlock Hash", "Hash", block.Hash().Hex())
-		return genesis.Config, block.Hash(), err
+		return genesis.Config, block.Hash(), nil
 	}
 
 	// We have the genesis block in database(perhaps in ancient database)
@@ -200,7 +200,10 @@ func SetupGenesisBlock(db ethdb.Database, snapshotBaseDB snapshotdb.BaseDB, gene
 			return genesis.Config, hash, &GenesisMismatchError{stored, hash}
 		}
 		block, err := genesis.Commit(db, snapshotBaseDB)
-		return genesis.Config, block.Hash(), err
+		if err != nil {
+			return genesis.Config, hash, err
+		}
+		return genesis.Config, block.Hash(), nil
 	}
 
 	// Check whether the genesis block is already written.

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -417,15 +417,15 @@ func TestIntermediateLeaks(t *testing.T) {
 
 	// Modify the transient state.
 	for i := byte(0); i < 255; i++ {
-		modify(transState, common.Address{byte(i)}, i, 0)
+		modify(transState, common.Address{i}, i, 0)
 	}
 	// Write modifications to trie.
 	transState.IntermediateRoot(false)
 
 	// Overwrite all the data with new values in the transient database.
 	for i := byte(0); i < 255; i++ {
-		modify(transState, common.Address{byte(i)}, i, 99)
-		modify(finalState, common.Address{byte(i)}, i, 99)
+		modify(transState, common.Address{i}, i, 99)
+		modify(finalState, common.Address{i}, i, 99)
 	}
 
 	// Commit and cross check the databases.

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -117,18 +117,16 @@ func TestRecipientEmpty(t *testing.T) {
 	//	tx, err := decodeTx(common.Hex2Bytes("f8498080808080011ca09b16de9d5bdee2cf56c28d16275a4da68cd30273e2525f3959f5d62557489921a0372ebd8fb3345f7db7b5a86d42e24d36e983e259b0664ceb8c227ec9af572f3d"))
 	tx, err := decodeTx(common.Hex2Bytes(strTxRlpData))
 	if err != nil {
-		t.Error(err)
-		t.FailNow()
+		t.Fatal(err)
 	}
 
 	from, err := Sender(NewEIP155Signer(new(big.Int)), tx)
 	if err != nil {
-		t.Error(err)
-		t.FailNow()
+		t.Fatal(err)
 	}
 
 	if addr != from {
-		t.Error("derived address doesn't match")
+		t.Fatal("derived address doesn't match")
 	}
 }
 
@@ -163,14 +161,12 @@ func TestRecipientNormal(t *testing.T) {
 	tx, err := decodeTx(common.Hex2Bytes(str))
 
 	if err != nil {
-		t.Error(err)
-		t.FailNow()
+		t.Fatal(err)
 	}
 
 	from, err := Sender(NewEIP155Signer(new(big.Int)), tx)
 	if err != nil {
-		t.Error(err)
-		t.FailNow()
+		t.Fatal(err)
 	}
 
 	if addr != from {

--- a/crypto/secp256k1/libsecp256k1/src/asm/field_10x26_arm.s
+++ b/crypto/secp256k1/libsecp256k1/src/asm/field_10x26_arm.s
@@ -23,7 +23,7 @@ Note:
 	.eabi_attribute 10, 0 @ Tag_FP_arch = none
 	.eabi_attribute 24, 1 @ Tag_ABI_align_needed = 8-byte
 	.eabi_attribute 25, 1 @ Tag_ABI_align_preserved = 8-byte, except leaf SP
-	.eabi_attribute 30, 2 @ Tag_ABI_optimization_goals = Agressive Speed
+	.eabi_attribute 30, 2 @ Tag_ABI_optimization_goals = Aggressive Speed
 	.eabi_attribute 34, 1 @ Tag_CPU_unaligned_access = v6
 	.text
 

--- a/eth/api.go
+++ b/eth/api.go
@@ -250,6 +250,72 @@ func (api *PrivateDebugAPI) GetBadBlocks(ctx context.Context) ([]*BadBlockArgs, 
 	return results, nil
 }
 
+// AccountRangeResult returns a mapping from the hash of an account addresses
+// to its preimage. It will return the JSON null if no preimage is found.
+// Since a query can return a limited amount of results, a "next" field is
+// also present for paging.
+type AccountRangeResult struct {
+	Accounts map[common.Hash]*common.Address `json:"accounts"`
+	Next     common.Hash                     `json:"next"`
+}
+
+func accountRange(st state.Trie, start *common.Hash, maxResults int) (AccountRangeResult, error) {
+	if start == nil {
+		start = &common.Hash{0}
+	}
+	it := trie.NewIterator(st.NodeIterator(start.Bytes()))
+	result := AccountRangeResult{Accounts: make(map[common.Hash]*common.Address), Next: common.Hash{}}
+
+	if maxResults > AccountRangeMaxResults {
+		maxResults = AccountRangeMaxResults
+	}
+
+	for i := 0; i < maxResults && it.Next(); i++ {
+		if preimage := st.GetKey(it.Key); preimage != nil {
+			addr := &common.Address{}
+			addr.SetBytes(preimage)
+			result.Accounts[common.BytesToHash(it.Key)] = addr
+		} else {
+			result.Accounts[common.BytesToHash(it.Key)] = nil
+		}
+	}
+
+	if it.Next() {
+		result.Next = common.BytesToHash(it.Key)
+	}
+
+	return result, nil
+}
+
+// AccountRangeMaxResults is the maximum number of results to be returned per call
+const AccountRangeMaxResults = 256
+
+// AccountRange enumerates all accounts in the latest state
+func (api *PrivateDebugAPI) AccountRange(ctx context.Context, start *common.Hash, maxResults int) (AccountRangeResult, error) {
+	var statedb *state.StateDB
+	var err error
+	block := api.eth.blockchain.CurrentBlock()
+
+	if len(block.Transactions()) == 0 {
+		statedb, err = api.computeStateDB(block, defaultTraceReexec)
+		if err != nil {
+			return AccountRangeResult{}, err
+		}
+	} else {
+		_, _, statedb, err = api.computeTxEnv(block.Hash(), len(block.Transactions())-1, 0)
+		if err != nil {
+			return AccountRangeResult{}, err
+		}
+	}
+
+	trie, err := statedb.Database().OpenTrie(block.Header().Root)
+	if err != nil {
+		return AccountRangeResult{}, err
+	}
+
+	return accountRange(trie, start, maxResults)
+}
+
 // StorageRangeResult is the result of a debug_storageRangeAt API call.
 type StorageRangeResult struct {
 	Storage storageMap   `json:"storage"`

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -69,17 +69,17 @@ func (b *EthAPIBackend) CurrentBlock() *types.Block {
 	b.eth.blockchain.SetHead(number)
 }*/
 
-func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*types.Header, error) {
+func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error) {
 	// Pending block is only known by the miner
-	if blockNr == rpc.PendingBlockNumber {
+	if number == rpc.PendingBlockNumber {
 		block := b.eth.miner.PendingBlock()
 		return block.Header(), nil
 	}
 	// Otherwise resolve and return the block
-	if blockNr == rpc.LatestBlockNumber {
+	if number == rpc.LatestBlockNumber {
 		return b.eth.blockchain.CurrentBlock().Header(), nil
 	}
-	return b.eth.blockchain.GetHeaderByNumber(uint64(blockNr)), nil
+	return b.eth.blockchain.GetHeaderByNumber(uint64(number)), nil
 }
 
 func (b *EthAPIBackend) HeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Header, error) {
@@ -103,17 +103,17 @@ func (b *EthAPIBackend) HeaderByHash(ctx context.Context, hash common.Hash) (*ty
 	return b.eth.blockchain.GetHeaderByHash(hash), nil
 }
 
-func (b *EthAPIBackend) BlockByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*types.Block, error) {
+func (b *EthAPIBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Block, error) {
 	// Pending block is only known by the miner
-	if blockNr == rpc.PendingBlockNumber {
+	if number == rpc.PendingBlockNumber {
 		block := b.eth.miner.PendingBlock()
 		return block, nil
 	}
 	// Otherwise resolve and return the block
-	if blockNr == rpc.LatestBlockNumber {
+	if number == rpc.LatestBlockNumber {
 		return b.eth.blockchain.CurrentBlock(), nil
 	}
-	return b.eth.blockchain.GetBlockByNumber(uint64(blockNr)), nil
+	return b.eth.blockchain.GetBlockByNumber(uint64(number)), nil
 }
 
 func (b *EthAPIBackend) BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error) {

--- a/eth/api_test.go
+++ b/eth/api_test.go
@@ -17,8 +17,168 @@
 package eth
 
 import (
+	"bytes"
+	"fmt"
+	"github.com/AlayaNetwork/Alaya-Go/common"
+	"github.com/AlayaNetwork/Alaya-Go/core/rawdb"
+	"github.com/AlayaNetwork/Alaya-Go/core/state"
+	"github.com/AlayaNetwork/Alaya-Go/crypto"
+	"math/big"
+	"sort"
 	"testing"
 )
+
+func accountRangeTest(t *testing.T, trie *state.Trie, statedb *state.StateDB, start *common.Hash, requestedNum int, expectedNum int) AccountRangeResult {
+	result, err := accountRange(*trie, start, requestedNum)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Accounts) != expectedNum {
+		t.Fatalf("expected %d results.  Got %d", expectedNum, len(result.Accounts))
+	}
+
+	for _, address := range result.Accounts {
+		if address == nil {
+			t.Fatalf("null address returned")
+		}
+		if !statedb.Exist(*address) {
+			t.Fatalf("account not found in state %s", address.Hex())
+		}
+	}
+
+	return result
+}
+
+type resultHash []*common.Hash
+
+func (h resultHash) Len() int           { return len(h) }
+func (h resultHash) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+func (h resultHash) Less(i, j int) bool { return bytes.Compare(h[i].Bytes(), h[j].Bytes()) < 0 }
+
+func TestAccountRange(t *testing.T) {
+	var (
+		statedb  = state.NewDatabase(rawdb.NewMemoryDatabase())
+		state, _ = state.New(common.Hash{}, statedb)
+		addrs    = [AccountRangeMaxResults * 2]common.Address{}
+		m        = map[common.Address]bool{}
+	)
+
+	for i := range addrs {
+		hash := common.HexToHash(fmt.Sprintf("%x", i))
+		addr := common.BytesToAddress(crypto.Keccak256Hash(hash.Bytes()).Bytes())
+		addrs[i] = addr
+		state.SetBalance(addrs[i], big.NewInt(1))
+		if _, ok := m[addr]; ok {
+			t.Fatalf("bad")
+		} else {
+			m[addr] = true
+		}
+	}
+
+	state.Commit(true)
+	root := state.IntermediateRoot(true)
+
+	trie, err := statedb.OpenTrie(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("test getting number of results less than max")
+	accountRangeTest(t, &trie, state, &common.Hash{0x0}, AccountRangeMaxResults/2, AccountRangeMaxResults/2)
+
+	t.Logf("test getting number of results greater than max %d", AccountRangeMaxResults)
+	accountRangeTest(t, &trie, state, &common.Hash{0x0}, AccountRangeMaxResults*2, AccountRangeMaxResults)
+
+	t.Logf("test with empty 'start' hash")
+	accountRangeTest(t, &trie, state, nil, AccountRangeMaxResults, AccountRangeMaxResults)
+
+	t.Logf("test pagination")
+
+	// test pagination
+	firstResult := accountRangeTest(t, &trie, state, &common.Hash{0x0}, AccountRangeMaxResults, AccountRangeMaxResults)
+
+	t.Logf("test pagination 2")
+	secondResult := accountRangeTest(t, &trie, state, &firstResult.Next, AccountRangeMaxResults, AccountRangeMaxResults)
+
+	hList := make(resultHash, 0)
+	for h1, addr1 := range firstResult.Accounts {
+		h := &common.Hash{}
+		h.SetBytes(h1.Bytes())
+		hList = append(hList, h)
+		for h2, addr2 := range secondResult.Accounts {
+			// Make sure that the hashes aren't the same
+			if bytes.Equal(h1.Bytes(), h2.Bytes()) {
+				t.Fatalf("pagination test failed:  results should not overlap")
+			}
+
+			// If either address is nil, then it makes no sense to compare
+			// them as they might be two different accounts.
+			if addr1 == nil || addr2 == nil {
+				continue
+			}
+
+			// Since the two hashes are different, they should not have
+			// the same preimage, but let's check anyway in case there
+			// is a bug in the (hash, addr) map generation code.
+			if bytes.Equal(addr1.Bytes(), addr2.Bytes()) {
+				t.Fatalf("pagination test failed: addresses should not repeat")
+			}
+		}
+	}
+
+	// Test to see if it's possible to recover from the middle of the previous
+	// set and get an even split between the first and second sets.
+	t.Logf("test random access pagination")
+	sort.Sort(hList)
+	middleH := hList[AccountRangeMaxResults/2]
+	middleResult := accountRangeTest(t, &trie, state, middleH, AccountRangeMaxResults, AccountRangeMaxResults)
+	innone, infirst, insecond := 0, 0, 0
+	for h := range middleResult.Accounts {
+		if _, ok := firstResult.Accounts[h]; ok {
+			infirst++
+		} else if _, ok := secondResult.Accounts[h]; ok {
+			insecond++
+		} else {
+			innone++
+		}
+	}
+	if innone != 0 {
+		t.Fatalf("%d hashes in the 'middle' set were neither in the first not the second set", innone)
+	}
+	if infirst != AccountRangeMaxResults/2 {
+		t.Fatalf("Imbalance in the number of first-test results: %d != %d", infirst, AccountRangeMaxResults/2)
+	}
+	if insecond != AccountRangeMaxResults/2 {
+		t.Fatalf("Imbalance in the number of second-test results: %d != %d", insecond, AccountRangeMaxResults/2)
+	}
+}
+
+func TestEmptyAccountRange(t *testing.T) {
+	var (
+		statedb  = state.NewDatabase(rawdb.NewMemoryDatabase())
+		state, _ = state.New(common.Hash{}, statedb)
+	)
+
+	state.Commit(true)
+	root := state.IntermediateRoot(true)
+
+	trie, err := statedb.OpenTrie(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := accountRange(trie, &common.Hash{0x0}, AccountRangeMaxResults)
+	if err != nil {
+		t.Fatalf("Empty results should not trigger an error: %v", err)
+	}
+	if results.Next != common.HexToHash("0") {
+		t.Fatalf("Empty results should not return a second page")
+	}
+	if len(results.Accounts) != 0 {
+		t.Fatalf("Empty state should not return addresses: %v", results.Accounts)
+	}
+}
 
 func TestStorageRangeAt(t *testing.T) {
 	// Create a state where account 0x010000... has a few storage entries.

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -792,6 +792,11 @@ func (api *PrivateDebugAPI) computeTxEnv(blockHash common.Hash, txIndex int, ree
 	if err != nil {
 		return nil, vm.Context{}, nil, err
 	}
+
+	if txIndex == 0 && len(block.Transactions()) == 0 {
+		return nil, vm.Context{}, statedb, nil
+	}
+
 	// Recompute transactions up to the target index.
 	signer := types.NewEIP155Signer(api.eth.blockchain.Config().ChainID)
 	for idx, tx := range block.Transactions() {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1728,22 +1728,18 @@ func NewPrivateDebugAPI(b Backend) *PrivateDebugAPI {
 	return &PrivateDebugAPI{b: b}
 }
 
-// ChaindbProperty returns leveldb properties of the chain database.
+// ChaindbProperty returns leveldb properties of the key-value database.
 func (api *PrivateDebugAPI) ChaindbProperty(property string) (string, error) {
-	ldb, ok := api.b.ChainDb().(interface {
-		LDB() *leveldb.DB
-	})
-	if !ok {
-		return "", fmt.Errorf("chaindbProperty does not work for memory databases")
-	}
 	if property == "" {
 		property = "leveldb.stats"
 	} else if !strings.HasPrefix(property, "leveldb.") {
 		property = "leveldb." + property
 	}
-	return ldb.LDB().GetProperty(property)
+	return api.b.ChainDb().Stat(property)
 }
 
+// ChaindbCompact flattens the entire key-value database into a single level,
+// removing all unused slots and merging all keys.
 func (api *PrivateDebugAPI) ChaindbCompact() error {
 	ldb, ok := api.b.ChainDb().(interface {
 		LDB() *leveldb.DB

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -51,12 +51,12 @@ type Backend interface {
 
 	// Blockchain API
 	//SetHead(number uint64)
-	HeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*types.Header, error)
+	HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error)
 	HeaderByHash(ctx context.Context, blockHash common.Hash) (*types.Header, error)
 	HeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Header, error)
 	CurrentHeader() *types.Header
 	CurrentBlock() *types.Block
-	BlockByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*types.Block, error)
+	BlockByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Block, error)
 	BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error)
 	BlockByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Block, error)
 	StateAndHeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*state.StateDB, *types.Header, error)

--- a/signer/rules/rules_test.go
+++ b/signer/rules/rules_test.go
@@ -180,7 +180,7 @@ func TestSignTxRequest(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	fmt.Printf("to %v", to.Address().String())
+	t.Logf("to %v", to.Address().String())
 	resp, err := r.ApproveTx(&core.SignTxRequest{
 		Transaction: core.SendTxArgs{
 			From: *from,

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"github.com/AlayaNetwork/Alaya-Go/common/byteutil"
 	"io/ioutil"
 	"math/big"
 	"math/rand"
@@ -29,6 +28,8 @@ import (
 	"testing"
 	"testing/quick"
 	"time"
+
+	"github.com/AlayaNetwork/Alaya-Go/common/byteutil"
 
 	"github.com/AlayaNetwork/Alaya-Go/ethdb/leveldb"
 
@@ -58,7 +59,7 @@ func TestEmptyTrie(t *testing.T) {
 	var trie Trie
 	res := trie.Hash()
 	exp := emptyRoot
-	if res != common.Hash(exp) {
+	if res != exp {
 		t.Errorf("expected %x got %x", exp, res)
 	}
 }


### PR DESCRIPTION
eth: fix storageRangeAt for empty blocks (#18076)
common/bitutil: use result of TestBytes to prevent dead code elimination (#19846)
eth: add debug_accountRange (#17438)
core: check error before accessing potentially nil block 19854
internal/ethapi: fix debug.chaindbProperty 19856